### PR TITLE
fix(tab): handle falsy children component without rendering them

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,8 @@
+# Contributing
+
+## Start 
+
+Execute following command to start the storybook:  
+- `npm run build`
+- `npm start`
+

--- a/README.md
+++ b/README.md
@@ -5,3 +5,8 @@ npm i @wonderflow/react-components
 ```
 
 For more info check https://design.wonderflow.ai/
+
+## Contributing
+
+See [contributing.md](./CONTRIBUTING.md) to contribute to this project
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wonderflow/react-components",
-  "version": "2.22.0",
+  "version": "2.23.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@wonderflow/react-components",
-      "version": "2.22.0",
+      "version": "2.23.0",
       "license": "MIT",
       "dependencies": {
         "@bumaga/tabs": "0.2.0",

--- a/src/tab/tab.stories.tsx
+++ b/src/tab/tab.stories.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react'
 import { Tab } from './tab'
+import { Button } from '../button'
 
 export default {
   title: 'Components/Tab',
@@ -80,6 +81,22 @@ export const IconsTab = () => {
       <Tab.Panel icon="check" label="Tab 2">Panel 2</Tab.Panel>
       <Tab.Panel icon="smile" label="Tab 3">Panel 3</Tab.Panel>
       <Tab.Panel icon="star" label="Tab 4">Panel 4</Tab.Panel>
+    </Tab.Root>
+  )
+}
+
+export const ConditionalTab = () => {
+  const state = useState(0)
+  const [isVisible, setIsVisible] = useState(false)
+
+  return (
+    <Tab.Root state={state}>
+      <Tab.Panel label="Always visible">
+        Always visible
+        {' '}
+        <Button icon="eye" onClick={() => setIsVisible(!isVisible)}>Toggle new tab</Button>
+      </Tab.Panel>
+      {isVisible && <Tab.Panel label="Visible conditionally">Panel 2</Tab.Panel>}
     </Tab.Root>
   )
 }

--- a/src/tab/tab.tsx
+++ b/src/tab/tab.tsx
@@ -53,6 +53,8 @@ const TabRoot: React.FC<TabProps> = forwardRef<HTMLDivElement, TabProps>(({
   onChange,
   ...props
 }, forwardedRef) => {
+  children = Children.toArray(children).filter(Boolean)
+
   const innerState = useState(0)
   const tabState = state || innerState
   const [currentTab] = tabState


### PR DESCRIPTION
This pr fixes the issues [#152](https://github.com/wonderflow-bv/design/issues/152)